### PR TITLE
Use --data instead of --json in curl

### DIFF
--- a/org-assistant.el
+++ b/org-assistant.el
@@ -481,7 +481,7 @@ ARGS is expected to be a plist with the following keys:
                                        (let ((file (make-temp-file "json")))
                                          (with-temp-file file
                                            (insert (org-assistant--json-encode it)))
-                                         (list "--json" (concat "@" file))))
+                                         (list "--data" (concat "@" file))))
                                      nil))))))
                      (puthash ,request-id-var process org-assistant--request-processes-ht)
                      (set-process-sentinel
@@ -849,7 +849,8 @@ request."
                                 (if (stringp org-assistant-auth-function)
                                     org-assistant-auth-function
                                   (funcall org-assistant-auth-function))))
-    ("Content-Type" . "application/json; charset=utf-8")))
+    ("Content-Type" . "application/json; charset=utf-8")
+    ("Accept" . "application/json")))
 
 (defun org-assistant--queue-chat-request (request-id blocks)
   "Execute or queue the `org-assistant' request for BLOCKS.


### PR DESCRIPTION
--json was added in a March 2022 curl release. Older versions of curl (for example, the system curl on some MacOS installations) don't have this option. Since it's just a convenient abbreviation for --data with Content-Type and Accept headers, it doesn't have much benefit here. For backwards compatibility, set the headers explicitly and use --data.

Fixes #11 